### PR TITLE
Allows errors in "final switch"

### DIFF
--- a/source/core/internal/switch_.d
+++ b/source/core/internal/switch_.d
@@ -2,9 +2,6 @@ module core.internal.switch_;
 import core.internal.exception;
 import rt.cmp;
 
-// Backwards compat.
-alias __switch_error = __switch_errorT;
-
 /**
 Support for switch statements switching on strings.
 Params:

--- a/source/object.d
+++ b/source/object.d
@@ -8,6 +8,7 @@ import numem.lifetime;
 import numem.core.traits;
 import core.internal.hash;
 import core.internal.array;
+import core.internal.exception;
 
 //
 //          SETUP
@@ -1070,3 +1071,6 @@ static foreach (type; AliasSeq!(bool, byte, double, float, int, long, short, uby
 		}
 	});
 }
+
+// Backwards compat.
+alias __switch_error = __switch_errorT;


### PR DESCRIPTION
If you `assert(false)` in a `final switch` then `__switch_error` is needed but not visible from `object.d`

Fixes asserts in final switch, tested in LDC 1.38 to 1.40