### PR TITLE
Expose __ArrayCast

### DIFF
--- a/source/object.d
+++ b/source/object.d
@@ -9,6 +9,7 @@ import numem.core.traits;
 import core.internal.hash;
 import core.internal.array;
 import core.internal.exception;
+public import core.internal.array: __ArrayCast;
 
 //
 //          SETUP


### PR DESCRIPTION
This changes fixes that example:

```d
int main(string[] args)
{
    ubyte[2] A = [0, 1];
    ubyte[] data = A[];
    ushort[] c = cast(ushort[]) data[0..$]; // this cast calls __ArrayCast
    return 0;
}
```

Probably more stuff is expected in object.d namespace, but haven't yet seen those.