### PR TITLE
Typeinfo function

### DIFF
--- a/source/core/internal/array.d
+++ b/source/core/internal/array.d
@@ -141,11 +141,11 @@ void reserve(T)(ref T[] arr, size_t length) @trusted {
 	arr = (cast(T*)(nu_malloc(length * T.sizeof).ptr))[0 .. 0];
 }
 
-T[] _d_newarrayU(T)(size_t length, bool isShared = false) pure @trusted {
-	return (cast(T*) nu_malloc(length * T.sizeof).ptr)[0 .. length];
+T[] _d_newarrayU(T)(size_t length, bool isShared = false) @trusted {
+	return (cast(T*) nu_malloc(length * T.sizeof))[0 .. length];
 }
 
-T[] _d_newarrayT(T)(size_t length, bool isShared = false) pure @trusted {
+T[] _d_newarrayT(T)(size_t length, bool isShared = false) @trusted {
 	auto arr = _d_newarrayU!T(length);
 	(cast(byte[]) arr)[] = 0;
 	return arr;

--- a/source/object.d
+++ b/source/object.d
@@ -989,6 +989,29 @@ public:
     }
 }
 
+class TypeInfo_Function : TypeInfo {
+nothrow:
+public:
+
+    override
+    bool opEquals(Object o) const {
+        if (this is o)
+            return true;
+        auto s = cast(const TypeInfo_Function) o;
+        return s && this.deco == s.deco;
+    }
+
+    override const(void)[] initializer() nothrow pure const @safe {
+        return null;
+    }
+
+    TypeInfo next;
+
+    // Mangled function type string
+    string deco;
+}
+
+
 // BASIC TYPES
 import numem.core.meta : AliasSeq;
 static foreach (type; AliasSeq!(bool, byte, double, float, int, long, short, ubyte, uint, ulong, ushort, void, char, dchar, wchar)) {


### PR DESCRIPTION
- fixed `_d_newarrayU` and `_d_newarrayT` instantiations. Later on I understood that since they leak, they shouldn't be exposed by `nurt` anyway, so it's a bit by design
- Gamut test-suite wants `TypeInfo_Function`, I'm not sure where. This appease the linker.

